### PR TITLE
Update docker file to allow config overwriting

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM jenkins/jenkins:lts-jdk11
 ENV JAVA_OPTS -Djenkins.install.runSetupWizard=false
 ENV CASC_JENKINS_CONFIG /var/jenkins_home/casc.yaml
-COPY plugins.txt /usr/share/jenkins/ref/plugins.txt
+COPY plugins.txt /usr/share/jenkins/ref/
 RUN /usr/local/bin/install-plugins.sh < /usr/share/jenkins/ref/plugins.txt
-COPY casc.yaml /var/jenkins_home/casc.yaml
+COPY casc.yaml /var/jenkins_home/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM jenkins/jenkins:lts-jdk11
 ENV JAVA_OPTS -Djenkins.install.runSetupWizard=false
-ENV CASC_JENKINS_CONFIG /var/jenkins_home/casc.yaml
+ENV CASC_JENKINS_CONFIG /usr/share/jenkins/casc.yaml
 COPY plugins.txt /usr/share/jenkins/ref/
 RUN /usr/local/bin/install-plugins.sh < /usr/share/jenkins/ref/plugins.txt
-COPY casc.yaml /var/jenkins_home/
+COPY casc.yaml /usr/share/jenkins/casc.yaml

--- a/casc.yaml
+++ b/casc.yaml
@@ -16,7 +16,7 @@ jenkins:
     all:
       name: "all"
   projectNamingStrategy: "standard"
-  quietPeriod: 10
+  quietPeriod: 2
   remotingSecurity:
     enabled: true
   scmCheckoutRetryCount: 0


### PR DESCRIPTION
Can't overwrite content written to the volume (in this case we want to mount jenkins_home to a volume to preserve jobs and workspaces) so here we move the jenkins casc file outside of the jenkins_home directory